### PR TITLE
Connect4 drawing discs

### DIFF
--- a/src/connect4/core.rs
+++ b/src/connect4/core.rs
@@ -46,13 +46,8 @@ const BOARD_POS_OFFSET: (i32, i32) = (10, 10 + COLUMN_SELECTION_INDICATOR_POS_OF
 
 /// Constant definition for the screen size of the game window
 const SCREEN_SIZE: (f32, f32) = (
-<<<<<<< HEAD
     BOARD_TOTAL_SIZE.0 + (BOARD_POS_OFFSET.0 as f32),
     BOARD_TOTAL_SIZE.1 + (BOARD_POS_OFFSET.1 as f32),
-=======
-    BOARD_TOTAL_SIZE.0 + 32 as f32,
-    BOARD_TOTAL_SIZE.1 + (BOARD_POS_OFFSET.1 - 10 + 32) as f32,
->>>>>>> connect4
 );
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]

--- a/src/connect4/core.rs
+++ b/src/connect4/core.rs
@@ -46,8 +46,8 @@ const BOARD_POS_OFFSET: (i32, i32) = (10, 10 + COLUMN_SELECTION_INDICATOR_POS_OF
 
 /// Constant definition for the screen size of the game window
 const SCREEN_SIZE: (f32, f32) = (
-    BOARD_TOTAL_SIZE.0 + 32 as f32,
-    BOARD_TOTAL_SIZE.1 + (TURN_INDICATOR_BOX_SIZE_OFFSET.1 + TURN_INDICATOR_FONT_SIZE + 32) as f32,
+    BOARD_TOTAL_SIZE.0 + (BOARD_POS_OFFSET.0 as f32),
+    BOARD_TOTAL_SIZE.1 + (BOARD_POS_OFFSET.1 as f32),
 );
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
@@ -553,8 +553,6 @@ impl event::EventHandler for GameState {
             self.mouse_disabled = true;
             if self.board.insert(self.highlighted_column, self.turnIndicator.team, self.team_colors[self.turnIndicator.team as usize]) {
                 println!("Team {} drops token in col {}", self.turnIndicator.team, self.highlighted_column);
-                let val =  self.board.columns[self.highlighted_column as usize].cells[self.board.get_column_height(self.highlighted_column as usize)-1];
-                println!("Cell: {} {:?}", val.team, val.color);
                 self.turnIndicator.team = self.turnIndicator.team%2+1; //Change to other team's turn
             }
             self.mouse_disabled = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,10 +126,10 @@ impl GameState {
 
 //Main game loop - tweaked from example in GGEZ repo (see https://github.com/ggez/ggez/blob/master/examples/02_hello_world.rs)
 pub fn main() -> GameResult {
-    let cb = ggez::ContextBuilder::new("gamescloset", "cs510");
+    /*let cb = ggez::ContextBuilder::new("gamescloset", "cs510");
     let (ctx, event_loop) = &mut cb.build()?;
 
     let state = &mut GameState::new(ctx)?;
-    event::run(ctx, event_loop, state)
-    //connect4::core::main()
+    event::run(ctx, event_loop, state)*/
+    connect4::core::main()
 }


### PR DESCRIPTION
Did some quick work to get the drawing functionality in a good place. This includes:

- Identifying when the mouse is over a column and drawing a disc above the corresponding column.
- Dropping a disc when the mouse is clicked (ideally this would only work if the mouse is clicked and released in the same column, but a little more work needed to do that)
- Disc colors fill in properly.
- Board in proper size now